### PR TITLE
add cardreaders, gun flavor

### DIFF
--- a/Content.Client/Doors/DoorSystem.cs
+++ b/Content.Client/Doors/DoorSystem.cs
@@ -90,7 +90,8 @@ public sealed class DoorSystem : SharedDoorSystem
             UpdateSpriteLayers((entity.Owner, args.Sprite), prototype);
 
         if (_animationSystem.HasRunningAnimation(entity, DoorComponent.AnimationKey))
-            _animationSystem.Stop(entity.Owner, DoorComponent.AnimationKey);
+            //_animationSystem.Stop(entity.Owner, DoorComponent.AnimationKey);
+            return; // MNET14: Fix doors lagging their animations. TODO: Fix and replace with another solution
 
         UpdateAppearanceForDoorState(entity, args.Sprite, state);
     }

--- a/Content.Client/_Manifest/SignalAccessReader/DurationSignalAccessReaderSystem.cs
+++ b/Content.Client/_Manifest/SignalAccessReader/DurationSignalAccessReaderSystem.cs
@@ -63,11 +63,6 @@ public sealed class DurationSignalAccessReaderSystem : SharedDurationSignalAcces
             return;
 
         AppearanceSystem.TryGetData<DurationSignalAccessReaderState?>(reader.Owner, DurationSignalAccessReaderVisuals.State, out var state, appearanceComponent);
-        if (state != reader.Comp.CurrentState)
-        {
-            Log.Error("Mispredicted reader animation!");
-            return;
-        }
 
         if (_animationSystem.HasRunningAnimation(reader.Owner, ReaderAnimationKey))
             _animationSystem.Stop(reader.Owner, ReaderAnimationKey);
@@ -78,17 +73,13 @@ public sealed class DurationSignalAccessReaderSystem : SharedDurationSignalAcces
         {
             case DurationSignalAccessReaderState.Fail:
                 _spriteSystem.LayerSetVisible(spriteEntity, DurationSignalAccessReaderLayers.Fail, true);
-                Log.Debug("Playing fail");
                 _animationSystem.Play(reader.Owner, ReaderFailAnimation, ReaderAnimationKey);
                 break;
             case DurationSignalAccessReaderState.Success:
                 _spriteSystem.LayerSetVisible(spriteEntity, DurationSignalAccessReaderLayers.Success, true);
-                Log.Debug("Playing success");
-
                 _animationSystem.Play(reader.Owner, ReaderSuccessAnimation, ReaderAnimationKey);
                 break;
             default:
-                Log.Debug("Off");
                 _spriteSystem.LayerSetVisible(spriteEntity, DurationSignalAccessReaderLayers.Fail, false);
                 _spriteSystem.LayerSetVisible(spriteEntity, DurationSignalAccessReaderLayers.Success, false);
                 break;

--- a/Content.Client/_Manifest/SignalAccessReader/DurationSignalAccessReaderSystem.cs
+++ b/Content.Client/_Manifest/SignalAccessReader/DurationSignalAccessReaderSystem.cs
@@ -1,0 +1,99 @@
+using Content.Shared.MNET.CardReader;
+using Robust.Client.Animations;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+
+namespace Content.Client.MNET.CardReader;
+
+// This is kinda jank and i don't like it but whatever.
+public sealed class DurationSignalAccessReaderSystem : SharedDurationSignalAccessReaderSystem
+{
+    [Dependency] private readonly AnimationPlayerSystem _animationSystem = default!;
+    [Dependency] private readonly SpriteSystem _spriteSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DurationSignalAccessReaderComponent, AppearanceChangeEvent>(OnReaderAppearanceUpdated);
+    }
+
+    private static readonly Animation ReaderFailAnimation = new()
+    {
+        Length = TimeSpan.FromSeconds(0.5),
+        AnimationTracks =
+        {
+            new AnimationTrackSpriteFlick
+            {
+                LayerKey = DurationSignalAccessReaderLayers.Fail,
+                KeyFrames =
+                {
+                    new AnimationTrackSpriteFlick.KeyFrame(new RSI.StateId("red_unlit"), default)
+                }
+            }
+        }
+    };
+
+    private static readonly Animation ReaderSuccessAnimation = new()
+    {
+        Length = TimeSpan.FromSeconds(0.5),
+        AnimationTracks =
+        {
+            new AnimationTrackSpriteFlick
+            {
+                LayerKey = DurationSignalAccessReaderLayers.Success,
+                KeyFrames =
+                {
+                    new AnimationTrackSpriteFlick.KeyFrame(new RSI.StateId("green_unlit"), default)
+                }
+            }
+        }
+    };
+
+    private const string ReaderFailAnimationKey = "fail";
+    private const string ReaderSuccessAnimationKey = "success";
+
+    private void OnReaderAppearanceUpdated(Entity<DurationSignalAccessReaderComponent> reader, ref AppearanceChangeEvent args)
+    {
+        UpdateReaderAppearance(reader, args.Sprite, args.Component);
+    }
+
+    private void UpdateReaderAppearance(Entity<DurationSignalAccessReaderComponent> reader, SpriteComponent? spriteComponent = null, AppearanceComponent? appearanceComponent = null)
+    {
+        if (spriteComponent == null && !TryComp(reader, out spriteComponent))
+            return;
+
+        AppearanceSystem.TryGetData<DurationSignalAccessReaderState?>(reader.Owner, DurationSignalAccessReaderVisuals.State, out var state, appearanceComponent);
+
+        // If this transitions from fail to success (and vice versa) it will have both layers visible until it goes back to something else. But I cant be bothered to fix that.\
+        var spriteEntity = (reader.Owner, spriteComponent);
+        switch (state)
+        {
+            case DurationSignalAccessReaderState.Fail:
+                _spriteSystem.LayerSetVisible(spriteEntity, DurationSignalAccessReaderLayers.Fail, true);
+
+                if (!_animationSystem.HasRunningAnimation(reader.Owner, ReaderFailAnimationKey))
+                    _animationSystem.Play(reader.Owner, ReaderFailAnimation, ReaderFailAnimationKey);
+
+                break;
+            case DurationSignalAccessReaderState.Success:
+                _spriteSystem.LayerSetVisible(spriteEntity, DurationSignalAccessReaderLayers.Success, true);
+
+                if (!_animationSystem.HasRunningAnimation(reader.Owner, ReaderSuccessAnimationKey))
+                    _animationSystem.Play(reader.Owner, ReaderSuccessAnimation, ReaderSuccessAnimationKey);
+
+                break;
+            default:
+                _spriteSystem.LayerSetVisible(spriteEntity, DurationSignalAccessReaderLayers.Fail, false);
+                _spriteSystem.LayerSetVisible(spriteEntity, DurationSignalAccessReaderLayers.Success, false);
+                break;
+        }
+    }
+}
+
+public enum DurationSignalAccessReaderLayers : byte
+{
+    Base = 0,
+    Fail = 1,
+    Success = 2,
+}

--- a/Content.Client/_Manifest/SignalAccessReader/DurationSignalAccessReaderSystem.cs
+++ b/Content.Client/_Manifest/SignalAccessReader/DurationSignalAccessReaderSystem.cs
@@ -20,7 +20,7 @@ public sealed class DurationSignalAccessReaderSystem : SharedDurationSignalAcces
 
     private static readonly Animation ReaderFailAnimation = new()
     {
-        Length = TimeSpan.FromSeconds(0.5),
+        Length = TimeSpan.FromSeconds(0.15),
         AnimationTracks =
         {
             new AnimationTrackSpriteFlick
@@ -36,7 +36,7 @@ public sealed class DurationSignalAccessReaderSystem : SharedDurationSignalAcces
 
     private static readonly Animation ReaderSuccessAnimation = new()
     {
-        Length = TimeSpan.FromSeconds(0.5),
+        Length = TimeSpan.FromSeconds(0.15),
         AnimationTracks =
         {
             new AnimationTrackSpriteFlick
@@ -50,8 +50,7 @@ public sealed class DurationSignalAccessReaderSystem : SharedDurationSignalAcces
         }
     };
 
-    private const string ReaderFailAnimationKey = "fail";
-    private const string ReaderSuccessAnimationKey = "success";
+    public const string ReaderAnimationKey = "fail";
 
     private void OnReaderAppearanceUpdated(Entity<DurationSignalAccessReaderComponent> reader, ref AppearanceChangeEvent args)
     {
@@ -64,24 +63,29 @@ public sealed class DurationSignalAccessReaderSystem : SharedDurationSignalAcces
             return;
 
         AppearanceSystem.TryGetData<DurationSignalAccessReaderState?>(reader.Owner, DurationSignalAccessReaderVisuals.State, out var state, appearanceComponent);
+        if (state != reader.Comp.CurrentState)
+        {
+            Log.Error("Mispredicted reader animation!");
+            return;
+        }
 
-        // If this transitions from fail to success (and vice versa) it will have both layers visible until it goes back to something else. But I cant be bothered to fix that.\
+        if (_animationSystem.HasRunningAnimation(reader.Owner, ReaderAnimationKey))
+            _animationSystem.Stop(reader.Owner, ReaderAnimationKey);
+
+        // If this transitions from fail to success (and vice versa) it will have both layers visible until it goes back to something else. But that doesn't really seem like a problem.
         var spriteEntity = (reader.Owner, spriteComponent);
         switch (state)
         {
             case DurationSignalAccessReaderState.Fail:
                 _spriteSystem.LayerSetVisible(spriteEntity, DurationSignalAccessReaderLayers.Fail, true);
                 Log.Debug("Playing fail");
-                if (!_animationSystem.HasRunningAnimation(reader.Owner, ReaderFailAnimationKey))
-                    _animationSystem.Play(reader.Owner, ReaderFailAnimation, ReaderFailAnimationKey);
-
+                _animationSystem.Play(reader.Owner, ReaderFailAnimation, ReaderAnimationKey);
                 break;
             case DurationSignalAccessReaderState.Success:
                 _spriteSystem.LayerSetVisible(spriteEntity, DurationSignalAccessReaderLayers.Success, true);
                 Log.Debug("Playing success");
-                if (!_animationSystem.HasRunningAnimation(reader.Owner, ReaderSuccessAnimationKey))
-                    _animationSystem.Play(reader.Owner, ReaderSuccessAnimation, ReaderSuccessAnimationKey);
 
+                _animationSystem.Play(reader.Owner, ReaderSuccessAnimation, ReaderAnimationKey);
                 break;
             default:
                 Log.Debug("Off");

--- a/Content.Client/_Manifest/SignalAccessReader/DurationSignalAccessReaderSystem.cs
+++ b/Content.Client/_Manifest/SignalAccessReader/DurationSignalAccessReaderSystem.cs
@@ -60,7 +60,7 @@ public sealed class DurationSignalAccessReaderSystem : SharedDurationSignalAcces
 
     private void UpdateReaderAppearance(Entity<DurationSignalAccessReaderComponent> reader, SpriteComponent? spriteComponent = null, AppearanceComponent? appearanceComponent = null)
     {
-        if (spriteComponent == null && !TryComp(reader, out spriteComponent))
+        if (!Resolve(reader, ref spriteComponent, logMissing: false))
             return;
 
         AppearanceSystem.TryGetData<DurationSignalAccessReaderState?>(reader.Owner, DurationSignalAccessReaderVisuals.State, out var state, appearanceComponent);
@@ -71,19 +71,20 @@ public sealed class DurationSignalAccessReaderSystem : SharedDurationSignalAcces
         {
             case DurationSignalAccessReaderState.Fail:
                 _spriteSystem.LayerSetVisible(spriteEntity, DurationSignalAccessReaderLayers.Fail, true);
-
+                Log.Debug("Playing fail");
                 if (!_animationSystem.HasRunningAnimation(reader.Owner, ReaderFailAnimationKey))
                     _animationSystem.Play(reader.Owner, ReaderFailAnimation, ReaderFailAnimationKey);
 
                 break;
             case DurationSignalAccessReaderState.Success:
                 _spriteSystem.LayerSetVisible(spriteEntity, DurationSignalAccessReaderLayers.Success, true);
-
+                Log.Debug("Playing success");
                 if (!_animationSystem.HasRunningAnimation(reader.Owner, ReaderSuccessAnimationKey))
                     _animationSystem.Play(reader.Owner, ReaderSuccessAnimation, ReaderSuccessAnimationKey);
 
                 break;
             default:
+                Log.Debug("Off");
                 _spriteSystem.LayerSetVisible(spriteEntity, DurationSignalAccessReaderLayers.Fail, false);
                 _spriteSystem.LayerSetVisible(spriteEntity, DurationSignalAccessReaderLayers.Success, false);
                 break;

--- a/Content.Server/_Manifest/SignalAccessReader/DurationSignalAccessReaderSystem.cs
+++ b/Content.Server/_Manifest/SignalAccessReader/DurationSignalAccessReaderSystem.cs
@@ -1,27 +1,21 @@
 using Content.Server.DeviceLinking.Systems;
 using Content.Shared.MNET.CardReader;
-using Robust.Server.GameObjects;
 
 namespace Content.Server.MNET.CardReader;
 
 public sealed class DurationSignalAccessReaderSystem : SharedDurationSignalAccessReaderSystem
 {
     [Dependency] private readonly DeviceLinkSystem _deviceLinkSystem = default!;
-    [Dependency] private readonly AppearanceSystem _appearanceSystem = default!;
 
     public override void ReaderFailed(Entity<DurationSignalAccessReaderComponent> reader, EntityUid user)
     {
         base.ReaderFailed(reader, user);
-
-        var (uid, component) = reader;
-        _deviceLinkSystem.SendSignal(uid, component.FailurePort, true);
+        _deviceLinkSystem.InvokePort(reader.Owner, reader.Comp.FailurePort);
     }
 
     public override void ReaderSuccess(Entity<DurationSignalAccessReaderComponent> reader, EntityUid user)
     {
         base.ReaderSuccess(reader, user);
-
-        var (uid, component) = reader;
-        _deviceLinkSystem.SendSignal(uid, component.SuccessPort, true);
+        _deviceLinkSystem.InvokePort(reader.Owner, reader.Comp.SuccessPort);
     }
 }

--- a/Content.Server/_Manifest/SignalAccessReader/DurationSignalAccessReaderSystem.cs
+++ b/Content.Server/_Manifest/SignalAccessReader/DurationSignalAccessReaderSystem.cs
@@ -1,0 +1,27 @@
+using Content.Server.DeviceLinking.Systems;
+using Content.Shared.MNET.CardReader;
+using Robust.Server.GameObjects;
+
+namespace Content.Server.MNET.CardReader;
+
+public sealed class DurationSignalAccessReaderSystem : SharedDurationSignalAccessReaderSystem
+{
+    [Dependency] private readonly DeviceLinkSystem _deviceLinkSystem = default!;
+    [Dependency] private readonly AppearanceSystem _appearanceSystem = default!;
+
+    public override void ReaderFailed(Entity<DurationSignalAccessReaderComponent> reader, EntityUid user)
+    {
+        base.ReaderFailed(reader, user);
+
+        var (uid, component) = reader;
+        _deviceLinkSystem.SendSignal(uid, component.FailurePort, true);
+    }
+
+    public override void ReaderSuccess(Entity<DurationSignalAccessReaderComponent> reader, EntityUid user)
+    {
+        base.ReaderSuccess(reader, user);
+
+        var (uid, component) = reader;
+        _deviceLinkSystem.SendSignal(uid, component.SuccessPort, true);
+    }
+}

--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -225,7 +225,7 @@ public sealed partial class GunComponent : Component
     /// When the gun is next available to be shot.
     /// Can be set multiple times in a single tick due to guns firing faster than a single tick time.
     /// </summary>
-    [DataField(customTypeSerializer:typeof(TimeOffsetSerializer))]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     [AutoNetworkedField]
     [AutoPausedField]
     public TimeSpan NextFire = TimeSpan.Zero;
@@ -263,6 +263,24 @@ public sealed partial class GunComponent : Component
     /// </summary>
     [DataField]
     public Vector2 DefaultDirection = new Vector2(0, -1);
+
+    // MNET14
+    /// <summary>
+    /// Loc for popup to be shown, on the user's entity, when trying to fire an ammo-less gun.
+    /// </summary>
+    [DataField]
+    public string? EmptyFireLoc = "gun-fired-empty-entity";
+
+    // MNET14
+    /// <summary>
+    /// Minimum time passed between empty fires to play the empty firing effect.
+    /// </summary>
+    [DataField]
+    public TimeSpan EmptyFireInterval = TimeSpan.FromMilliseconds(40);
+
+    // MNET14
+    [AutoNetworkedField]
+    public bool LastShotWasEmpty = false;
 }
 
 [Flags]

--- a/Content.Shared/_Manifest/CardReader/DurationSignalAccessReaderComponent.cs
+++ b/Content.Shared/_Manifest/CardReader/DurationSignalAccessReaderComponent.cs
@@ -98,18 +98,3 @@ public sealed partial class DurationSignalAccessReaderDoAfterEvent : DoAfterEven
 {
     public override DoAfterEvent Clone() => this;
 }
-
-[Serializable, NetSerializable]
-public enum DurationSignalAccessReaderVisuals : byte
-{
-    State,
-};
-
-
-[Serializable, NetSerializable]
-public enum DurationSignalAccessReaderState : byte
-{
-    Off = 0,
-    Fail = 1,
-    Success = 2,
-}

--- a/Content.Shared/_Manifest/CardReader/DurationSignalAccessReaderComponent.cs
+++ b/Content.Shared/_Manifest/CardReader/DurationSignalAccessReaderComponent.cs
@@ -1,0 +1,115 @@
+using Content.Shared.DeviceLinking;
+using Content.Shared.DoAfter;
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared.MNET.CardReader;
+
+/// <summary>
+/// Component that, after an interaction doafter, sends a devicenet signal based on access of the user.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(fieldDeltas: true), AutoGenerateComponentPause]
+public sealed partial class DurationSignalAccessReaderComponent : Component
+{
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan NextStateChange = TimeSpan.Zero;
+
+    /// <summary>
+    /// Amount of time upon a state change to an active state (Fail/Success) before transitioning to inactive state (Off).
+    /// </summary>
+    [DataField]
+    public TimeSpan StateChangeTime = TimeSpan.FromSeconds(0.5);
+
+    [DataField, AutoNetworkedField]
+    public DurationSignalAccessReaderState CurrentState = DurationSignalAccessReaderState.Off;
+
+    /// <summary>
+    /// Can DoorBumpOpeners colliding with this in-air, interact with it?
+    /// </summary>
+    [DataField]
+    public bool BumpAccessible = true;
+
+    /// <summary>
+    /// Length of the DoAfter to interact with this.
+    /// </summary>
+    [DataField]
+    public TimeSpan InteractionLength = TimeSpan.FromSeconds(0.3);
+
+    /// <summary>
+    /// Chance that the user will have to repeat the interaction doafter.
+    /// </summary>
+    [DataField]
+    public float RepeatChance = 0.5f;
+
+    /// <summary>
+    /// Popup text shown to the user when they have to repeat the interaction.
+    /// <see cref="RepeatPopupOthers"/> isn't shown if this is null. Why? I'm lazy.
+    /// </summary>
+    [DataField]
+    public string? RepeatPopupSelf = "durationaccessreader-fumble-self";
+
+    /// <summary>
+    /// Popup text shown to people other than the user when they have to repeat the interaction.
+    /// Is not shown if <see cref="RepeatPopupSelf"/> is null. Why? I'm lazy.
+    /// </summary>
+    [DataField]
+    public string? RepeatPopupOthers = "durationaccessreader-fumble-others";
+
+    #region Signals
+    /// <summary>
+    /// Port triggered upon failed interaction.
+    /// </summary>
+    [DataField, ViewVariables]
+    public ProtoId<SourcePortPrototype> FailurePort = "Off";
+
+    /// <summary>
+    /// Port triggered upon successful interaction.
+    /// </summary>
+    [DataField, ViewVariables]
+    public ProtoId<SourcePortPrototype> SuccessPort = "On";
+
+    #endregion
+    #region Sound
+    /// <summary>
+    /// Sound played upon starting interaction.
+    /// </summary>
+    [DataField, ViewVariables]
+    public SoundSpecifier? StartSound;
+
+    /// <summary>
+    /// Sound played upon failed interaction.
+    /// </summary>
+    [DataField, ViewVariables]
+    public SoundSpecifier? FailureSound;
+
+    /// <summary>
+    /// Sound played upon successful interaction.
+    /// </summary>
+    [DataField, ViewVariables]
+    public SoundSpecifier? SuccessSound;
+    #endregion
+}
+
+[Serializable, NetSerializable]
+public sealed partial class DurationSignalAccessReaderDoAfterEvent : DoAfterEvent
+{
+    public override DoAfterEvent Clone() => this;
+}
+
+[Serializable, NetSerializable]
+public enum DurationSignalAccessReaderVisuals : byte
+{
+    State,
+};
+
+
+[Serializable, NetSerializable]
+public enum DurationSignalAccessReaderState : byte
+{
+    Off = 0,
+    Fail = 1,
+    Success = 2,
+}

--- a/Content.Shared/_Manifest/CardReader/DurationSignalAccessReaderSystem.cs
+++ b/Content.Shared/_Manifest/CardReader/DurationSignalAccessReaderSystem.cs
@@ -1,0 +1,165 @@
+using Content.Shared.Access.Systems;
+using Content.Shared.DeviceLinking;
+using Content.Shared.DoAfter;
+using Content.Shared.Doors.Systems;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Interaction;
+using Content.Shared.Popups;
+using Content.Shared.Random.Helpers;
+using Content.Shared.Tag;
+using Content.Shared.Timing;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Events;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.MNET.CardReader;
+
+public abstract class SharedDurationSignalAccessReaderSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _sharedPopupSystem = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
+    [Dependency] private readonly SharedDeviceLinkSystem _deviceLinkSystem = default!;
+    [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
+    [Dependency] protected readonly SharedAppearanceSystem AppearanceSystem = default!;
+    [Dependency] private readonly AccessReaderSystem _accessReaderSystem = default!;
+    [Dependency] private readonly UseDelaySystem _useDelaySystem = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly TagSystem _tagSystem = default!;
+
+    public const string ReaderUseDelayId = "signalAccessReader";
+
+    private readonly HashSet<Entity<DurationSignalAccessReaderComponent>> _activeReaders = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DurationSignalAccessReaderComponent, ComponentInit>(OnReaderInit);
+        SubscribeLocalEvent<DurationSignalAccessReaderComponent, ComponentRemove>(OnReaderRemove);
+
+        SubscribeLocalEvent<DurationSignalAccessReaderComponent, StartCollideEvent>(OnReaderCollide);
+
+        SubscribeLocalEvent<DurationSignalAccessReaderComponent, ActivateInWorldEvent>(OnReaderActivated);
+        SubscribeLocalEvent<DurationSignalAccessReaderComponent, DurationSignalAccessReaderDoAfterEvent>(OnReaderFinishDoAfter);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        foreach (var (uid, component) in _activeReaders)
+        {
+            if (_gameTiming.CurTime < component.NextStateChange)
+                continue;
+
+            SetReaderState((uid, component), DurationSignalAccessReaderState.Off);
+        }
+    }
+
+    // TODO: Unfuck appearance prediction
+    public void SetReaderState(Entity<DurationSignalAccessReaderComponent> reader, DurationSignalAccessReaderState state)
+    {
+        reader.Comp.CurrentState = state;
+        AppearanceSystem.SetData(reader.Owner, DurationSignalAccessReaderVisuals.State, state);
+
+        if (state == DurationSignalAccessReaderState.Fail ||
+            state == DurationSignalAccessReaderState.Success)
+        {
+            _activeReaders.Add(reader);
+            reader.Comp.NextStateChange = _gameTiming.CurTime + reader.Comp.StateChangeTime;
+        }
+        else
+            _activeReaders.Remove(reader);
+    }
+
+    private void OnReaderInit(Entity<DurationSignalAccessReaderComponent> reader, ref ComponentInit args)
+    {
+        var (uid, component) = reader;
+        _deviceLinkSystem.EnsureSourcePorts(uid, component.FailurePort, component.SuccessPort);
+    }
+
+    private void OnReaderRemove(Entity<DurationSignalAccessReaderComponent> reader, ref ComponentRemove args)
+    {
+        _activeReaders.Remove(reader);
+    }
+
+    private void OnReaderCollide(Entity<DurationSignalAccessReaderComponent> reader, ref StartCollideEvent args)
+    {
+        if (!reader.Comp.BumpAccessible)
+            return;
+
+        if (TryComp<UseDelayComponent>(reader, out var useDelay) && !_useDelaySystem.TryResetDelay((reader, useDelay), true, ReaderUseDelayId))
+            return;
+
+        if (args.OtherBody.BodyStatus != BodyStatus.InAir)
+            return;
+
+        var collidingEntity = args.OtherEntity;
+        if (_tagSystem.HasTag(collidingEntity, SharedDoorSystem.DoorBumpTag))
+        {
+            if (_accessReaderSystem.IsAllowed(collidingEntity, reader.Owner))
+                ReaderSuccess(reader, collidingEntity);
+            else
+                ReaderFailed(reader, collidingEntity);
+        }
+    }
+
+    private void OnReaderActivated(Entity<DurationSignalAccessReaderComponent> reader, ref ActivateInWorldEvent args)
+    {
+        if (!args.Complex || args.Handled)
+            return;
+
+        if (TryComp<UseDelayComponent>(reader, out var useDelay) && !_useDelaySystem.TryResetDelay((reader, useDelay), true, ReaderUseDelayId))
+            return;
+
+        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, reader.Comp.InteractionLength, new DurationSignalAccessReaderDoAfterEvent(), reader.Owner));
+    }
+
+    private void OnReaderFinishDoAfter(Entity<DurationSignalAccessReaderComponent> reader, ref DurationSignalAccessReaderDoAfterEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        // This is a reallyneat trick, thanks to whoever made this hashcodecombine implementation.
+        var (readerUid, readerComponent) = reader;
+        var seed = SharedRandomExtensions.HashCodeCombine(new() { (int)_gameTiming.CurTick.Value, GetNetEntity(readerUid).Id }); // sandbox violation giveaway if you make it `[...] instead of `new() { ... }`
+
+        // fumble if unlucky enough
+        if (new System.Random(seed).Prob(readerComponent.RepeatChance))
+        {
+            // popup is only shown to user
+            if (readerComponent.RepeatPopupSelf is { } selfRepeatLoc && _gameTiming.IsFirstTimePredicted)
+            {
+                if (readerComponent.RepeatPopupOthers is { } othersRepeatLoc)
+                    _sharedPopupSystem.PopupPredicted(Loc.GetString(selfRepeatLoc), Loc.GetString(othersRepeatLoc, ("name", Identity.Entity(args.User, EntityManager))), reader, args.User, PopupType.SmallCaution);
+                else
+                    _sharedPopupSystem.PopupPredicted(Loc.GetString(selfRepeatLoc), reader, args.User, PopupType.SmallCaution);
+            }
+
+            args.Repeat = true;
+            return;
+        }
+
+        if (!_accessReaderSystem.IsAllowed(args.User, readerUid))
+        {
+            ReaderFailed(reader, args.User);
+            return;
+        }
+
+        ReaderSuccess(reader, args.User);
+    }
+
+    public virtual void ReaderFailed(Entity<DurationSignalAccessReaderComponent> reader, EntityUid user)
+    {
+        _audioSystem.PlayPredicted(reader.Comp.FailureSound, reader.Owner, user);
+        SetReaderState(reader, DurationSignalAccessReaderState.Fail);
+    }
+
+    public virtual void ReaderSuccess(Entity<DurationSignalAccessReaderComponent> reader, EntityUid user)
+    {
+        _audioSystem.PlayPredicted(reader.Comp.SuccessSound, reader.Owner, user);
+        SetReaderState(reader, DurationSignalAccessReaderState.Success);
+    }
+}

--- a/Content.Shared/_Manifest/CardReader/DurationSignalAccessReaderSystem.cs
+++ b/Content.Shared/_Manifest/CardReader/DurationSignalAccessReaderSystem.cs
@@ -59,13 +59,12 @@ public abstract class SharedDurationSignalAccessReaderSystem : EntitySystem
         }
     }
 
-    // TODO: Unfuck appearance prediction
+    // TODO: Fix appearance prediction
     public bool SetReaderState(Entity<DurationSignalAccessReaderComponent> reader, DurationSignalAccessReaderState state)
     {
         if (state == reader.Comp.CurrentState)
             return false;
 
-        Log.Debug($"Setting state to {Enum.GetName(state)} from {Enum.GetName(reader.Comp.CurrentState)}");
         reader.Comp.CurrentState = state;
         AppearanceSystem.SetData(reader.Owner, DurationSignalAccessReaderVisuals.State, state);
 

--- a/Content.Shared/_Manifest/CardReader/DurationSignalAccessReaderSystem.cs
+++ b/Content.Shared/_Manifest/CardReader/DurationSignalAccessReaderSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Random.Helpers;
 using Content.Shared.Tag;
 using Content.Shared.Timing;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Network;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Random;
@@ -47,7 +48,8 @@ public abstract class SharedDurationSignalAccessReaderSystem : EntitySystem
 
     public override void Update(float frameTime)
     {
-        base.Update(frameTime);
+        if (!_gameTiming.IsFirstTimePredicted)
+            return;
 
         foreach (var (uid, component) in _activeReaders)
         {
@@ -114,12 +116,17 @@ public abstract class SharedDurationSignalAccessReaderSystem : EntitySystem
         if (TryComp<UseDelayComponent>(reader, out var useDelay) && !_useDelaySystem.TryResetDelay((reader, useDelay), true, ReaderUseDelayId))
             return;
 
-        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, reader.Comp.InteractionLength, new DurationSignalAccessReaderDoAfterEvent(), reader.Owner));
+        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, reader.Comp.InteractionLength, new DurationSignalAccessReaderDoAfterEvent(), reader.Owner)
+        {
+            BreakOnWeightlessMove = false,
+            BreakOnMove = true,
+            NeedHand = true,
+        });
     }
 
     private void OnReaderFinishDoAfter(Entity<DurationSignalAccessReaderComponent> reader, ref DurationSignalAccessReaderDoAfterEvent args)
     {
-        if (args.Cancelled)
+        if (args.Cancelled || !_gameTiming.IsFirstTimePredicted)
             return;
 
         // This is a reallyneat trick, thanks to whoever made this hashcodecombine implementation.

--- a/Content.Shared/_Manifest/CardReader/DurationSignalAccessReaderSystem.cs
+++ b/Content.Shared/_Manifest/CardReader/DurationSignalAccessReaderSystem.cs
@@ -9,7 +9,6 @@ using Content.Shared.Random.Helpers;
 using Content.Shared.Tag;
 using Content.Shared.Timing;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Network;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Random;
@@ -19,15 +18,15 @@ namespace Content.Shared.MNET.CardReader;
 
 public abstract class SharedDurationSignalAccessReaderSystem : EntitySystem
 {
+    [Dependency] protected readonly SharedAppearanceSystem AppearanceSystem = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly TagSystem _tagSystem = default!;
     [Dependency] private readonly SharedPopupSystem _sharedPopupSystem = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly SharedDeviceLinkSystem _deviceLinkSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
-    [Dependency] protected readonly SharedAppearanceSystem AppearanceSystem = default!;
     [Dependency] private readonly AccessReaderSystem _accessReaderSystem = default!;
     [Dependency] private readonly UseDelaySystem _useDelaySystem = default!;
-    [Dependency] private readonly IGameTiming _gameTiming = default!;
-    [Dependency] private readonly TagSystem _tagSystem = default!;
 
     public const string ReaderUseDelayId = "signalAccessReader";
 
@@ -61,8 +60,12 @@ public abstract class SharedDurationSignalAccessReaderSystem : EntitySystem
     }
 
     // TODO: Unfuck appearance prediction
-    public void SetReaderState(Entity<DurationSignalAccessReaderComponent> reader, DurationSignalAccessReaderState state)
+    public bool SetReaderState(Entity<DurationSignalAccessReaderComponent> reader, DurationSignalAccessReaderState state)
     {
+        if (state == reader.Comp.CurrentState)
+            return false;
+
+        Log.Debug($"Setting state to {Enum.GetName(state)} from {Enum.GetName(reader.Comp.CurrentState)}");
         reader.Comp.CurrentState = state;
         AppearanceSystem.SetData(reader.Owner, DurationSignalAccessReaderVisuals.State, state);
 
@@ -74,6 +77,9 @@ public abstract class SharedDurationSignalAccessReaderSystem : EntitySystem
         }
         else
             _activeReaders.Remove(reader);
+
+        DirtyFields(reader, reader.Comp, null, nameof(DurationSignalAccessReaderComponent.CurrentState), nameof(DurationSignalAccessReaderComponent.NextStateChange));
+        return true;
     }
 
     private void OnReaderInit(Entity<DurationSignalAccessReaderComponent> reader, ref ComponentInit args)
@@ -116,7 +122,7 @@ public abstract class SharedDurationSignalAccessReaderSystem : EntitySystem
         if (TryComp<UseDelayComponent>(reader, out var useDelay) && !_useDelaySystem.TryResetDelay((reader, useDelay), true, ReaderUseDelayId))
             return;
 
-        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, reader.Comp.InteractionLength, new DurationSignalAccessReaderDoAfterEvent(), reader.Owner)
+        args.Handled = _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, reader.Comp.InteractionLength, new DurationSignalAccessReaderDoAfterEvent(), reader.Owner)
         {
             BreakOnWeightlessMove = false,
             BreakOnMove = true,
@@ -126,7 +132,7 @@ public abstract class SharedDurationSignalAccessReaderSystem : EntitySystem
 
     private void OnReaderFinishDoAfter(Entity<DurationSignalAccessReaderComponent> reader, ref DurationSignalAccessReaderDoAfterEvent args)
     {
-        if (args.Cancelled || !_gameTiming.IsFirstTimePredicted)
+        if (args.Cancelled)
             return;
 
         // This is a reallyneat trick, thanks to whoever made this hashcodecombine implementation.

--- a/Content.Shared/_Manifest/CardReader/Enums.cs
+++ b/Content.Shared/_Manifest/CardReader/Enums.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.MNET.CardReader;
+
+[Serializable, NetSerializable]
+public enum DurationSignalAccessReaderVisuals : byte
+{
+    State,
+};
+
+
+[Serializable, NetSerializable]
+public enum DurationSignalAccessReaderState : byte
+{
+    Off = 0,
+    Fail = 1,
+    Success = 2,
+}

--- a/Resources/Locale/en-US/_MNET/weapons/ranged/gun.ftl
+++ b/Resources/Locale/en-US/_MNET/weapons/ranged/gun.ftl
@@ -1,0 +1,1 @@
+gun-fired-empty-entity = *click* *click*


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
added cardreaders that read your access and send a signal
added more flavor to gun dryfiring
fixed doors skipping their animations

## TODO
todo: fix cardreader animation playing twice

## Technical details
goidacoded

## Media

https://github.com/user-attachments/assets/26c685fa-ae1a-47f4-9d2c-a93cb170647f


